### PR TITLE
create() should return DatabaseConfig<T>.insert() response

### DIFF
--- a/src/__tests__/create.test.ts
+++ b/src/__tests__/create.test.ts
@@ -2,6 +2,7 @@ import { factory } from '..';
 
 describe('create tests', () => {
   interface FactoryType {
+    id?: number;
     email: string;
     name: string;
   }
@@ -9,12 +10,24 @@ describe('create tests', () => {
   const User = factory<FactoryType>(fake => ({
     email: fake.internet.email(),
     name: fake.name.firstName(),
-  }));
+  })).onInsert(async (data: FactoryType) => ({ id: 1, ...data }));
 
   it('should create a single object', async () => {
     const data = await User.create();
 
     expect(typeof data).toBe('object');
+    expect(data).toHaveProperty('name');
+    expect(typeof data.name).toBe('string');
+    expect(data).toHaveProperty('email');
+    expect(typeof data.email).toBe('string');
+  });
+
+  it('should create a single object and return OnInsertMethod response', async () => {
+    const data = await User.create();
+
+    expect(typeof data).toBe('object');
+    expect(data).toHaveProperty('id');
+    expect(typeof data.id).toBe('number');
     expect(data).toHaveProperty('name');
     expect(typeof data.name).toBe('string');
     expect(data).toHaveProperty('email');

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -76,8 +76,7 @@ const factory = <T, A = GenericExtension<T>>(generator: FactoryGenerator<T>) => 
       );
     }
 
-    await database.insert(mock);
-    return database.hydrate(mock);
+    return database.hydrate(await database.insert(mock));
   };
 
   const only = (keys: keyof T | Array<keyof T>, count?: number | Overrides<T>, overrides?: Overrides<T>) => {


### PR DESCRIPTION
Ran into issues when trying to reference object properties that were only included in the [ `onInsert` / [DatabaseConfig<T>.insert()](https://github.com/olavoasantos/node-factory/blob/master/src/types.ts#L61)] response.

```typescript
export const UserFactory = factory<User>(fake => {
  const firstName = fake.name.firstName();
  const lastName = fake.name.lastName();
  const email = fake.internet.email(firstName, lastName);

  return {
    // not generating an id here - leaving that up to onInsert()
    firstName: firstName,
    lastName: lastName,
    email: email,
    password: fake.internet.password()
  };
}).onInsert((data: User) => Container.get(UserRepository).add(data));

const user = await UserFactory.create();

// this would fail because user.id was undefined
const vendorApplication = await VendorApplicationFactory.create({ user: user });
```
